### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,42 @@
+{
+  "name": "color-themes-for-google-code-prettify",
+  "version": "0.0.1",
+  "main": [
+    "./css/themes/github.css",
+  	"./css/themes/hemisu-dark.css",
+  	"./css/themes/hemisu-light.css",
+  	"./css/themes/tomorrow.css",
+  	"./css/themes/tomorrow-night.css",
+  	"./css/themes/tomorrow-night-blue.css",
+  	"./css/themes/tomorrow-night-bright.css",
+  	"./css/themes/tomorrow-night-eighties.css",
+  	"./css/themes/vibrant-ink.css"
+  ],
+  "homepage": "https://github.com/jmblog/color-themes-for-google-code-prettify",
+  "authors": [
+    "Yoshihide Jimbo <yjimbo@gmail.com>"
+  ],
+  "description": "Syntax highlighting color themes for Google Code Prettify",
+  "keywords": [
+    "Prettify"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "font",
+    "github",
+    "hemisu-dark",
+    "hemisu-light",
+    "img",
+    "js",
+    "tomorrow-night-blue",
+    "tomorrow-night-bright",
+    "tomorrow-night-eighties",
+    "tomorrow-night",
+    "tomorrow",
+    "vibrant-ink",
+    "channel.html",
+    "index.html",
+    "robots.txt",
+    "sitemap.xml"
+  ]
+}


### PR DESCRIPTION
Hi Yoshihide Jimbo,

I am a newbie in this, i registered and erase the package, i hope you can register the package properly.

After deleted the package, and then try again, i get: "Package not found"

But if i try install: "bower install color-themes-for-google-code-prettify" I get the package. 

After merge, you can try install Package: 

http://bower.io/docs/creating-packages/#register

Example: "bower register color-themes-for-google-code-prettify https://github.com/jmblog/color-themes-for-google-code-prettify"

The idea with this, when someone try: "bower info color-themes-for-google-code-prettify" Get this: 

{
  name: 'color-themes-for-google-code-prettify',
  homepage: 'https://github.com/jmblog/color-themes-for-google-code-prettify'
}

and not this: 

{
  name: 'color-themes-for-google-code-prettify',
  homepage: 'https://github.com/romelgomez/color-themes-for-google-code-prettify'
}

Best wishes.